### PR TITLE
Distribute changes for ios and android

### DIFF
--- a/packages/@icon-magic/config-reader/src/schemas/config-schema.ts
+++ b/packages/@icon-magic/config-reader/src/schemas/config-schema.ts
@@ -51,6 +51,14 @@ const distributeConfigProperties = {
         type: ['boolean', 'null']
       }
     }
+  },
+  webp: {
+    type: ['object', null],
+    properties: {
+      namePrefix: {
+        type: ['string', 'null']
+      }
+    }
   }
 };
 

--- a/packages/@icon-magic/distribute/src/create-image-set.ts
+++ b/packages/@icon-magic/distribute/src/create-image-set.ts
@@ -32,19 +32,22 @@ export async function createImageSet(iconSet: IconSet, outputPath: string) {
     const assets = getIconFlavorsByType(icon, 'png');
     const promises = [];
     const ASSET_CATALOG = 'Contents.json'; // as defined for iOS
+    let iconOutputPath = outputPath;
+
+    // prepend the outputPath with the category so output icons are categorized
+    // by category name
+    if (icon.category) {
+      iconOutputPath = path.join(iconOutputPath, icon.category);
+    }
+
     for (const asset of assets) {
-      let assetNameForCatalog = `${icon.iconName}_${path.basename(
+      const assetNameForCatalog = `${icon.iconName}_${path.basename(
         asset.getPath()
       )}`;
 
-      // if the category is present, prepend it to the name
-      if (icon.category) {
-        assetNameForCatalog = `${icon.category}_${assetNameForCatalog}`;
-      }
-
       // strip the resolution from the asset name to get the name of the imageset
       const outputIconDir = path.join(
-        outputPath,
+        iconOutputPath,
         `${assetNameForCatalog.split('@')[0]}.imageset`
       );
 

--- a/packages/@icon-magic/distribute/src/distribute-by-resolution.ts
+++ b/packages/@icon-magic/distribute/src/distribute-by-resolution.ts
@@ -6,6 +6,8 @@ import * as path from 'path';
 import { getAssetResolutionFromName, getIconFlavorsByType } from './utils';
 const LOGGER: Logger = logger('icon-magic:distribute:distribute-by-resolution');
 
+const ICON_NAME_PREFIX = 'ic';
+
 /**
  * Distributes icons into different folders based on the resolution
  * This is needed for Android
@@ -27,11 +29,26 @@ export async function distributeByResolution(
       // the output folder is the folder by resolution
       outputIconDir = path.join(outputPath, getAssetResolutionFromName(asset));
 
-      let assetName = `${icon.iconName}_${path.basename(asset.getPath())}`;
+      // get the asset name by prepending the icon name
+      // also making both of them kebab case
+      let assetName = asset.name.replace(/-/g, '_').split('@')[0];
+      const iconName = icon.iconName.replace(/-/g, '_');
+      assetName = `${iconName}_${assetName}${path.extname(asset.getPath())}`;
+
       // if the category is present, prepend it to the name
       if (icon.category) {
         assetName = `${icon.category}_${assetName}`;
       }
+
+      // by default the icon prefix is ICON_NAME_PREFIX which can be overridden in
+      // the distribute config
+      const namePrefix =
+        (icon.distribute &&
+          icon.distribute.webp &&
+          icon.distribute.webp.namePrefix) ||
+        ICON_NAME_PREFIX;
+
+      assetName = `${namePrefix}_${assetName}`;
 
       await fs.mkdirp(outputIconDir);
 

--- a/packages/@icon-magic/icon-models/src/interface.ts
+++ b/packages/@icon-magic/icon-models/src/interface.ts
@@ -18,8 +18,12 @@ export interface AssetConfig {
 }
 
 interface SVGOptions {
-  toSprite: boolean;
-  spriteName: string;
+  toSprite?: boolean;
+  spriteName?: string;
+}
+
+interface WebpOptions {
+  namePrefix?: string;
 }
 
 export interface spriteConfig {
@@ -89,6 +93,7 @@ export interface GenerateConfig {
  */
 export interface DistributeConfig {
   svg?: SVGOptions;
+  webp?: WebpOptions;
 }
 
 /**


### PR DESCRIPTION
- Converting all names to contain only underscores (convention for mobile)
- Ios: Prepending a category for imagesets
- Android: Removing the resolution from the name. Adding a name prefix of ic_