### PR TITLE
Ensuring we pick the largest matching key from nameSizeMapping

### DIFF
--- a/packages/@icon-magic/generate/src/plugins/svg-generate.ts
+++ b/packages/@icon-magic/generate/src/plugins/svg-generate.ts
@@ -78,6 +78,8 @@ export const svgGenerate: GeneratePlugin = {
 
         // get the size from the mapping that is passed in. This is a pattern
         // matching of the key and not necessarily the key itself
+        // once a pattern is matched, we check to see if it's the longest
+        // matching key to ensure that the correct size is obtained from the name
         let flavorSize;
         let matchedLength = 0;
         for (const key in nameSizeMapping) {

--- a/packages/@icon-magic/generate/src/plugins/svg-generate.ts
+++ b/packages/@icon-magic/generate/src/plugins/svg-generate.ts
@@ -79,8 +79,13 @@ export const svgGenerate: GeneratePlugin = {
         // get the size from the mapping that is passed in. This is a pattern
         // matching of the key and not necessarily the key itself
         let flavorSize;
+        let matchedLength = 0;
         for (const key in nameSizeMapping) {
-          if (flavorName.match(key)) flavorSize = nameSizeMapping[key];
+          const regExMatch = flavorName.match(key);
+          if (regExMatch && matchedLength < regExMatch.length) {
+            matchedLength = regExMatch.length;
+            flavorSize = nameSizeMapping[key];
+          }
         }
 
         if (!flavorSize) {

--- a/packages/@icon-magic/generate/src/plugins/svg-to-raster.ts
+++ b/packages/@icon-magic/generate/src/plugins/svg-to-raster.ts
@@ -64,8 +64,13 @@ export const svgToRaster: GeneratePlugin = {
 
         // get the size from the mapping that is passed in. This is a pattern
         // matching of the key and not necessarily the key itself
+        let matchedLength = 0;
         for (const key in nameSizeMapping) {
-          if (flavorName.match(key)) sizeFromMapping = nameSizeMapping[key];
+          const regExMatch = flavorName.match(key);
+          if (regExMatch && matchedLength < regExMatch.length) {
+            matchedLength = regExMatch.length;
+            sizeFromMapping = nameSizeMapping[key];
+          }
         }
 
         if (sizeFromMapping) {

--- a/packages/@icon-magic/generate/src/plugins/svg-to-raster.ts
+++ b/packages/@icon-magic/generate/src/plugins/svg-to-raster.ts
@@ -64,6 +64,8 @@ export const svgToRaster: GeneratePlugin = {
 
         // get the size from the mapping that is passed in. This is a pattern
         // matching of the key and not necessarily the key itself
+        // once a pattern is matched, we check to see if it's the longest
+        // matching key to ensure that the correct size is obtained from the name
         let matchedLength = 0;
         for (const key in nameSizeMapping) {
           const regExMatch = flavorName.match(key);


### PR DESCRIPTION
- This was causing errors when we had names like
    "nameSizeMapping": {
      "xxsmall": {
        "width": 56,
        "height": 14
      },
      "xsmall": {
        "width": 84,
        "height": 21
      },
      "small":{
        "width": 110,
        "height": 28
      }
   }