### PR TITLE
Distribute to folder with category name

### DIFF
--- a/packages/@icon-magic/cli/src/index.ts
+++ b/packages/@icon-magic/cli/src/index.ts
@@ -73,7 +73,7 @@ program
   )
   .option(
     '-g, --groupBy [groupBy]',
-    '[for web sprite creation] how to group the icons. The only available option for now is `--groupBy category`'
+    '[for web] how to group the icons. The only available option for now is `--groupBy category`. \n For sprites, icons are grouped with <defs> tags with IDs matching the category and for non-sprites \n this distributes svgs in folder matching the category.'
   )
   .action(async (inputPaths, options) => {
     if (!inputPaths.length) {

--- a/packages/@icon-magic/distribute/src/distribute-svg.ts
+++ b/packages/@icon-magic/distribute/src/distribute-svg.ts
@@ -73,6 +73,7 @@ export async function distributeSvg(
       const destPath = icon.category
         ? path.join(outputPath, icon.category)
         : outputPath;
+      LOGGER.debug(destPath);
       await copyIconAssetSvgs(icon.iconName, assetsNoSprite, destPath);
     }
   }

--- a/packages/@icon-magic/distribute/src/distribute-svg.ts
+++ b/packages/@icon-magic/distribute/src/distribute-svg.ts
@@ -68,8 +68,12 @@ export async function distributeSvg(
         spriteNames
       );
     } else {
-      // Just copy the files to the output
-      await copyIconAssetSvgs(icon.iconName, assetsNoSprite, outputPath);
+      // Just copy the files to the output and put them in a folder that matches
+      // the icon category
+      const destPath = icon.category
+        ? path.join(outputPath, icon.category)
+        : outputPath;
+      await copyIconAssetSvgs(icon.iconName, assetsNoSprite, destPath);
     }
   }
   // After we've gone through all the icons, write the sprites to a file

--- a/packages/@icon-magic/distribute/src/distribute-svg.ts
+++ b/packages/@icon-magic/distribute/src/distribute-svg.ts
@@ -68,12 +68,13 @@ export async function distributeSvg(
         spriteNames
       );
     } else {
-      // Just copy the files to the output and put them in a folder that matches
-      // the icon category
-      const destPath = icon.category
-        ? path.join(outputPath, icon.category)
-        : outputPath;
-      LOGGER.debug(destPath);
+      // Just copy the files to the output
+      // If the groupByCategory flag is available,
+      // put them in a folder that matches the icon category
+      const destPath =
+        icon.category && groupByCategory
+          ? path.join(outputPath, icon.category)
+          : outputPath;
       await copyIconAssetSvgs(icon.iconName, assetsNoSprite, destPath);
     }
   }

--- a/packages/@icon-magic/distribute/test/fixtures/out/icons.svg
+++ b/packages/@icon-magic/distribute/test/fixtures/out/icons.svg
@@ -1,65 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" 
-  xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
-  <defs id="app">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" id="point-default" data-supported-dps="40x40">
-      <defs>
-        <linearGradient id="a" x1="34.78" y1="3.84" x2="14.66" y2="25.84" gradientUnits="userSpaceOnUse">
-          <stop offset="0" stop-color="#665ed0"/>
-          <stop offset="1" stop-color="#0073b1"/>
-        </linearGradient>
-      </defs>
-      <g fill="url(#a)">
-        <path d="M20 11.88A8.13 8.13 0 1 1 11.88 20 8.13 8.13 0 0 1 20 11.88M20 9a11 11 0 1 0 11 11A11 11 0 0 0 20 9z"/>
-        <circle cx="20" cy="20" r="4"/>
-      </g>
-      <circle cx="20" cy="20" r="2" transform="rotate(-45 20.002 19.995)" fill="#33aada"/>
-      <path fill="#33aada" d="M24.246 12.932l2.829 2.828-5.657 5.657-2.828-2.829z"/>
-      <path fill="#33aada" d="M29.19 16.46l-4.95-.7-.7-4.95 4.94-4.95L29 11l5.14.52-4.95 4.94z"/>
-    </svg>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" id="point-default-2" data-supported-dps="40x40">
-      <defs>
-        <linearGradient id="a" x1="34.78" y1="3.84" x2="14.66" y2="25.84" gradientUnits="userSpaceOnUse">
-          <stop offset="0" stop-color="#665ed0"/>
-          <stop offset="1" stop-color="#0073b1"/>
-        </linearGradient>
-      </defs>
-      <g fill="url(#a)">
-        <path d="M20 11.88A8.13 8.13 0 1 1 11.88 20 8.13 8.13 0 0 1 20 11.88M20 9a11 11 0 1 0 11 11A11 11 0 0 0 20 9z"/>
-        <circle cx="20" cy="20" r="4"/>
-      </g>
-      <circle cx="20" cy="20" r="2" transform="rotate(-45 20.002 19.995)" fill="#33aada"/>
-      <path fill="#33aada" d="M24.246 12.932l2.829 2.828-5.657 5.657-2.828-2.829z"/>
-      <path fill="#33aada" d="M29.19 16.46l-4.95-.7-.7-4.95 4.94-4.95L29 11l5.14.52-4.95 4.94z"/>
-    </svg>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" id="ads-default" data-supported-dps="40x40">
-      <defs>
-        <linearGradient id="a" x1="34.78" y1="3.84" x2="14.66" y2="25.84" gradientUnits="userSpaceOnUse">
-          <stop offset="0" stop-color="#665ed0"/>
-          <stop offset="1" stop-color="#0073b1"/>
-        </linearGradient>
-      </defs>
-      <g fill="url(#a)">
-        <path d="M20 11.88A8.13 8.13 0 1 1 11.88 20 8.13 8.13 0 0 1 20 11.88M20 9a11 11 0 1 0 11 11A11 11 0 0 0 20 9z"/>
-        <circle cx="20" cy="20" r="4"/>
-      </g>
-      <circle cx="20" cy="20" r="2" transform="rotate(-45 20.002 19.995)" fill="#33aada"/>
-      <path fill="#33aada" d="M24.246 12.932l2.829 2.828-5.657 5.657-2.828-2.829z"/>
-      <path fill="#33aada" d="M29.19 16.46l-4.95-.7-.7-4.95 4.94-4.95L29 11l5.14.52-4.95 4.94z"/>
-    </svg>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" id="ads-default-2" data-supported-dps="40x40">
-      <defs>
-        <linearGradient id="a" x1="34.78" y1="3.84" x2="14.66" y2="25.84" gradientUnits="userSpaceOnUse">
-          <stop offset="0" stop-color="#665ed0"/>
-          <stop offset="1" stop-color="#0073b1"/>
-        </linearGradient>
-      </defs>
-      <g fill="url(#a)">
-        <path d="M20 11.88A8.13 8.13 0 1 1 11.88 20 8.13 8.13 0 0 1 20 11.88M20 9a11 11 0 1 0 11 11A11 11 0 0 0 20 9z"/>
-        <circle cx="20" cy="20" r="4"/>
-      </g>
-      <circle cx="20" cy="20" r="2" transform="rotate(-45 20.002 19.995)" fill="#33aada"/>
-      <path fill="#33aada" d="M24.246 12.932l2.829 2.828-5.657 5.657-2.828-2.829z"/>
-      <path fill="#33aada" d="M29.19 16.46l-4.95-.7-.7-4.95 4.94-4.95L29 11l5.14.52-4.95 4.94z"/>
-    </svg>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"><defs id="app"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" id="point-default" data-supported-dps="40x40"><defs><linearGradient id="a" x1="34.78" y1="3.84" x2="14.66" y2="25.84" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#665ed0"/><stop offset="1" stop-color="#0073b1"/></linearGradient></defs><g fill="url(#a)"><path d="M20 11.88A8.13 8.13 0 1 1 11.88 20 8.13 8.13 0 0 1 20 11.88M20 9a11 11 0 1 0 11 11A11 11 0 0 0 20 9z"/><circle cx="20" cy="20" r="4"/></g><circle cx="20" cy="20" r="2" transform="rotate(-45 20.002 19.995)" fill="#33aada"/><path fill="#33aada" d="M24.246 12.932l2.829 2.828-5.657 5.657-2.828-2.829z"/><path fill="#33aada" d="M29.19 16.46l-4.95-.7-.7-4.95 4.94-4.95L29 11l5.14.52-4.95 4.94z"/></svg><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" id="point-default-2" data-supported-dps="40x40">
+  <defs>
+    <linearGradient id="a" x1="34.78" y1="3.84" x2="14.66" y2="25.84" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#665ed0"/>
+      <stop offset="1" stop-color="#0073b1"/>
+    </linearGradient>
   </defs>
-</svg>
+  <g fill="url(#a)">
+    <path d="M20 11.88A8.13 8.13 0 1 1 11.88 20 8.13 8.13 0 0 1 20 11.88M20 9a11 11 0 1 0 11 11A11 11 0 0 0 20 9z"/>
+    <circle cx="20" cy="20" r="4"/>
+  </g>
+  <circle cx="20" cy="20" r="2" transform="rotate(-45 20.002 19.995)" fill="#33aada"/>
+  <path fill="#33aada" d="M24.246 12.932l2.829 2.828-5.657 5.657-2.828-2.829z"/>
+  <path fill="#33aada" d="M29.19 16.46l-4.95-.7-.7-4.95 4.94-4.95L29 11l5.14.52-4.95 4.94z"/>
+</svg><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" id="ads-default" data-supported-dps="40x40"><defs><linearGradient id="a" x1="34.78" y1="3.84" x2="14.66" y2="25.84" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#665ed0"/><stop offset="1" stop-color="#0073b1"/></linearGradient></defs><g fill="url(#a)"><path d="M20 11.88A8.13 8.13 0 1 1 11.88 20 8.13 8.13 0 0 1 20 11.88M20 9a11 11 0 1 0 11 11A11 11 0 0 0 20 9z"/><circle cx="20" cy="20" r="4"/></g><circle cx="20" cy="20" r="2" transform="rotate(-45 20.002 19.995)" fill="#33aada"/><path fill="#33aada" d="M24.246 12.932l2.829 2.828-5.657 5.657-2.828-2.829z"/><path fill="#33aada" d="M29.19 16.46l-4.95-.7-.7-4.95 4.94-4.95L29 11l5.14.52-4.95 4.94z"/></svg><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" id="ads-default-2" data-supported-dps="40x40">
+  <defs>
+    <linearGradient id="a" x1="34.78" y1="3.84" x2="14.66" y2="25.84" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#665ed0"/>
+      <stop offset="1" stop-color="#0073b1"/>
+    </linearGradient>
+  </defs>
+  <g fill="url(#a)">
+    <path d="M20 11.88A8.13 8.13 0 1 1 11.88 20 8.13 8.13 0 0 1 20 11.88M20 9a11 11 0 1 0 11 11A11 11 0 0 0 20 9z"/>
+    <circle cx="20" cy="20" r="4"/>
+  </g>
+  <circle cx="20" cy="20" r="2" transform="rotate(-45 20.002 19.995)" fill="#33aada"/>
+  <path fill="#33aada" d="M24.246 12.932l2.829 2.828-5.657 5.657-2.828-2.829z"/>
+  <path fill="#33aada" d="M29.19 16.46l-4.95-.7-.7-4.95 4.94-4.95L29 11l5.14.52-4.95 4.94z"/>
+</svg></defs></svg>

--- a/packages/@icon-magic/distribute/test/fixtures/out/ui-icon/achievement/filled.svg
+++ b/packages/@icon-magic/distribute/test/fixtures/out/ui-icon/achievement/filled.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" id="a-home-filled-1" data-supported-dps="8x8 16x16" fill="currentColor">
+  <path d="M28 13.36L16.64 6.19a1.2 1.2 0 0 0-1.28 0L4 13.34l1 1.59 2-1.25V25a1 1 0 0 0 1 1h6v-5h4v5h6a1 1 0 0 0 1-1V13.67L27 15z"/>
+</svg>


### PR DESCRIPTION
Distribute to folder with category name. So we can run `icon-magic distribute out/reactions out/ghost out/illustrations out/banners` all at once instead of:

`icon-magic distribute out/reactions -o static/images/reactions/`
`icon-magic distribute out/ghost -o static/images/ghost/`
`icon-magic distribute out/illustrations -o static/images/illustrations`
`icon-magic distribute out/banners o static/images/banners`
