### PR TITLE
add debug flag to cli commands

### DIFF
--- a/packages/@icon-magic/build/src/index.ts
+++ b/packages/@icon-magic/build/src/index.ts
@@ -35,9 +35,11 @@ const LOGGER: Logger = logger('icon-magic:build:index');
  */
 export async function build(
   iconConfig: IconConfigHash,
-  hashing = true
+  hashing = true,
+  debug = false
 ): Promise<IconSet> {
-  LOGGER.debug('Icon build has begun');
+  LOGGER.setDebuggingState(debug);
+  LOGGER.debug('Icon build has begun')
   TIMER.start();
   // Create icons for all icons within the iconConfig
   const iconSet = new IconSet(iconConfig);

--- a/packages/@icon-magic/build/src/index.ts
+++ b/packages/@icon-magic/build/src/index.ts
@@ -39,7 +39,7 @@ export async function build(
   debug = false
 ): Promise<IconSet> {
   LOGGER.setDebuggingState(debug);
-  LOGGER.debug('Icon build has begun')
+  LOGGER.debug('Icon build has begun');
   TIMER.start();
   // Create icons for all icons within the iconConfig
   const iconSet = new IconSet(iconConfig);

--- a/packages/@icon-magic/cli/README.md
+++ b/packages/@icon-magic/cli/README.md
@@ -57,6 +57,10 @@ icon-magic build .
 icon-magic build icons/
 ```
 
+Options:
+-h, --hashing', Default: `true`. When true, builds only those icon variants that have changed since the previous execution. If false, builds all icons.
+-d, --debug, Default: `false`. When true, will output debbugging info to the command-line.
+
 Given a set of input directories, finds the closest [config file](../config-reader/README.md) (iconrc.json/iconrc.js/icon) and "builds" the icons from it. Refer to
 [@icon-magic/build](../build/README.md) for more details.
 
@@ -69,6 +73,9 @@ icon-magic generate .
 ```
 icon-magic generate icons/
 ```
+
+Options:
+-h, --hashing', Default: `true`. When true, builds only those icon variants that have changed since the previous execution. If false, builds all icons.
 
 Given a directory of icons (each icon containing it's own config file consisting
 of all the flavors from the build step), the generate step is responsible for
@@ -89,5 +96,6 @@ Options:
 -o, --outputPath Path to the output directory where the generated assets are to be written to
 -t, --type type of icons format to handle, accepted types are svg|png|webp
 -g, --groupBy [currently the only supported use is for web sprite creation] if to how to group the icons by category
+-d, --debug, when used will output debbugging info to the command-line.
 
 Refer [@icon-magic/distribute](../distribute/README.md) for more details.

--- a/packages/@icon-magic/cli/src/index.ts
+++ b/packages/@icon-magic/cli/src/index.ts
@@ -22,6 +22,9 @@ program
     '-h, --hashing',
     'When true(default), builds only those icon variants that have changed since the previous execution. If false, builds all icons'
   )
+  .option(
+    '-d, --debug', 'Default is false.  When true, will log debugging info to the command-line'
+  )
   .action(async (inputPaths, options) => {
     if (!inputPaths.length) {
       LOGGER.error(
@@ -33,7 +36,7 @@ program
     const iconSet = getIconConfigSet(inputPaths);
 
     // build all the icons
-    await build(iconSet, options.hashing);
+    await build(iconSet, options.hashing, options.debug);
 
     // exit without any errors
     process.exit(0);
@@ -86,6 +89,9 @@ program
     '-h --outputAsTemplate',
     '[for web] whether to output the svg as handlebars template.'
   )
+  .option(
+    '-d, --debug', 'Default is false.  When true, will log debugging info to the command-line'
+  )
   .action(async (inputPaths, options) => {
     if (!inputPaths.length) {
       LOGGER.error('No Input Directories were specified.\n');
@@ -126,7 +132,8 @@ program
       options.outputPath,
       options.type,
       options.groupBy === 'category',
-      options.outputAsTemplate
+      options.outputAsTemplate,
+      options.debug
     );
 
     // exit without any errors
@@ -141,12 +148,15 @@ program
     '-h, --hashing',
     'When true(default), builds only those icon variants that have changed since the previous execution. If false, builds all icons'
   )
+  .option(
+    '-d, --debug', 'Default is false.  When true, will log debugging info to the command-line'
+  )
   .action(async (inputPaths, options) => {
     // Get the iconSet from the inputPaths
     const iconSet = getIconConfigSet(inputPaths);
 
     // build all the icons
-    const outputIconSet = await build(iconSet, options.hashing);
+    const outputIconSet = await build(iconSet, options.hashing, options.debug);
 
     // generate all the icons
     await iconGenerate.generate(outputIconSet, options.hashing);

--- a/packages/@icon-magic/distribute/src/index.ts
+++ b/packages/@icon-magic/distribute/src/index.ts
@@ -22,7 +22,9 @@ export async function distributeByType(
   type: ICON_TYPES = 'all',
   groupByCategory = true,
   outputAsHbs = false,
+  debug = false
 ): Promise<void> {
+  LOGGER.setDebuggingState(debug);
   LOGGER.debug(`entering distribute with ${type}`);
   const iconSet = new IconSet(iconConfig, true);
   switch (type) {

--- a/packages/@icon-magic/logger/src/index.ts
+++ b/packages/@icon-magic/logger/src/index.ts
@@ -26,6 +26,7 @@ export interface Logger {
   error: (msg: string) => void;
   debug: (msg: string) => void;
   info: (msg: string) => void;
+  setDebuggingState: (debug: boolean) => void;
 }
 
 /**
@@ -33,15 +34,22 @@ export interface Logger {
  * @param fileName name of the file that's added as a label to the logging data
  */
 export function logger(fileName: string): Logger {
+  let debugState = false;
+
   return {
     error: function(msg: string): void {
       winstonLogger.error({ message: msg, label: fileName });
     },
     debug: function(msg: string): void {
-      winstonLogger.debug({ message: msg, label: fileName });
+      if (debugState) {
+        winstonLogger.debug({ message: msg, label: fileName });
+      }
     },
     info: function(msg: string): void {
       winstonLogger.info({ message: msg, label: fileName });
+    },
+    setDebuggingState: function(debug: boolean): void {
+      debugState = debug;
     }
   };
 }


### PR DESCRIPTION
- users now need to use a debug flag to see command-line output
- users will Not see debug output by default

- still need to find the best way to test this behavior
-  currently manually testing running the scripts locally and the flag works fine.