### PR TITLE
add the -d, --debug flag, change logger() to class logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.7.2",
+    "commander": "^5.0.0",
     "lerna": "^3.4.3",
     "mocha": "^7.2.0",
     "mocha-typescript": "^1.1.17",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.7.2",
-    "commander": "^5.0.0",
     "lerna": "^3.4.3",
     "mocha": "^7.2.0",
     "mocha-typescript": "^1.1.17",

--- a/packages/@icon-magic/build/src/index.ts
+++ b/packages/@icon-magic/build/src/index.ts
@@ -36,9 +36,7 @@ const LOGGER = new Logger('icon-magic:build:index');
 export async function build(
   iconConfig: IconConfigHash,
   hashing = true,
-  debug = false
 ): Promise<IconSet> {
-  LOGGER.setDebug(debug);
   LOGGER.debug('Icon build has begun');
   TIMER.start();
   // Create icons for all icons within the iconConfig

--- a/packages/@icon-magic/build/src/index.ts
+++ b/packages/@icon-magic/build/src/index.ts
@@ -12,13 +12,13 @@ import {
   createHash,
   saveContentToFile
 } from '@icon-magic/icon-models';
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import { timer } from '@icon-magic/timing';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
 const TIMER = timer();
-const LOGGER: Logger = logger('icon-magic:build:index');
+const LOGGER = new Logger('icon-magic:build:index');
 
 /**
  * The build is responsible for constructing all the various flavors that an
@@ -35,8 +35,10 @@ const LOGGER: Logger = logger('icon-magic:build:index');
  */
 export async function build(
   iconConfig: IconConfigHash,
-  hashing = true
+  hashing = true,
+  debug = false
 ): Promise<IconSet> {
+  LOGGER.setDebug(debug);
   LOGGER.debug('Icon build has begun');
   TIMER.start();
   // Create icons for all icons within the iconConfig

--- a/packages/@icon-magic/cli/README.md
+++ b/packages/@icon-magic/cli/README.md
@@ -76,6 +76,7 @@ icon-magic generate icons/
 
 Options:
 -h, --hashing', Default: `true`. When true, builds only those icon variants that have changed since the previous execution. If false, builds all icons.
+-d, --debug, Default: `false`. When true, will output debbugging info to the command-line.
 
 Given a directory of icons (each icon containing it's own config file consisting
 of all the flavors from the build step), the generate step is responsible for

--- a/packages/@icon-magic/cli/README.md
+++ b/packages/@icon-magic/cli/README.md
@@ -57,6 +57,10 @@ icon-magic build .
 icon-magic build icons/
 ```
 
+Options:
+-h, --hashing', Default: `true`. When true, builds only those icon variants that have changed since the previous execution. If false, builds all icons.
+-d, --debug, Default: `false`. When true, will output debbugging info to the command-line.
+
 Given a set of input directories, finds the closest [config file](../config-reader/README.md) (iconrc.json/iconrc.js/icon) and "builds" the icons from it. Refer to
 [@icon-magic/build](../build/README.md) for more details.
 
@@ -69,6 +73,9 @@ icon-magic generate .
 ```
 icon-magic generate icons/
 ```
+
+Options:
+-h, --hashing', Default: `true`. When true, builds only those icon variants that have changed since the previous execution. If false, builds all icons.
 
 Given a directory of icons (each icon containing it's own config file consisting
 of all the flavors from the build step), the generate step is responsible for
@@ -89,5 +96,6 @@ Options:
 -o, --outputPath Path to the output directory where the generated assets are to be written to
 -t, --type type of icons format to handle, accepted types are svg|png|webp
 -g, --groupBy [currently the only supported use is for web sprite creation] if to how to group the icons by category
+-d, --debug, when used will output debbugging info to the command-line.
 
 Refer [@icon-magic/distribute](../distribute/README.md) for more details.

--- a/packages/@icon-magic/cli/src/index.ts
+++ b/packages/@icon-magic/cli/src/index.ts
@@ -35,8 +35,11 @@ program
     // Get the iconSet from the inputPaths
     const iconSet = getIconConfigSet(inputPaths);
 
+    //set the debugState on the Logger Class using the commander flag
+    LOGGER.setDebug(options.debug);
+
     // build all the icons
-    await build(iconSet, options.hashing, options.debug);
+    await build(iconSet, options.hashing);
 
     // exit without any errors
     process.exit(0);
@@ -64,8 +67,11 @@ program
     // Get the iconSet from the inputPaths
     const iconSet = getIconConfigSet(inputPaths);
 
+    //set the debugState on the Logger Class using the commander flag
+    LOGGER.setDebug(options.debug);
+
     // generate all the icons
-    await iconGenerate.generateFromConfigHash(iconSet, options.hashing, options.debug);
+    await iconGenerate.generateFromConfigHash(iconSet, options.hashing);
 
     // exit without any errors
     process.exit(0);
@@ -129,6 +135,9 @@ program
     // Get the iconSet from the inputPaths
     const iconSet = getIconConfigSet(inputPaths);
 
+    //set the debugState on the Logger Class using the commander flag
+    LOGGER.setDebug(options.debug);
+
     // distribute the icons
     await distributeByType(
       iconSet,
@@ -136,7 +145,6 @@ program
       options.type,
       options.groupBy === 'category',
       options.outputAsTemplate,
-      options.debug
     );
 
     // exit without any errors
@@ -158,11 +166,14 @@ program
     // Get the iconSet from the inputPaths
     const iconSet = getIconConfigSet(inputPaths);
 
+    //set the debugState on the Logger Class using the commander flag
+    LOGGER.setDebug(options.debug);
+
     // build all the icons
-    const outputIconSet = await build(iconSet, options.hashing, options.debug);
+    const outputIconSet = await build(iconSet, options.hashing);
 
     // generate all the icons
-    await iconGenerate.generate(outputIconSet, options.hashing, options.debug);
+    await iconGenerate.generate(outputIconSet, options.hashing);
 
     // exit without any errors
     process.exit(0);

--- a/packages/@icon-magic/cli/src/index.ts
+++ b/packages/@icon-magic/cli/src/index.ts
@@ -4,11 +4,11 @@ import { build } from '@icon-magic/build';
 import { getIconConfigSet } from '@icon-magic/config-reader';
 import { distributeByType } from '@icon-magic/distribute';
 import * as iconGenerate from '@icon-magic/generate';
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import * as program from 'commander';
 import * as fs from 'fs-extra';
 
-const LOGGER: Logger = logger('@icon-magic/cli/index');
+const LOGGER = new Logger('@icon-magic/cli/index');
 const ICON_TYPES = ['svg', 'png', 'webp', 'all'];
 
 program.version(getVersion(), '-v, --version');
@@ -22,6 +22,9 @@ program
     '-h, --hashing',
     'When true(default), builds only those icon variants that have changed since the previous execution. If false, builds all icons'
   )
+  .option(
+    '-d, --debug', 'Default is false.  When true, will log debugging info to the command-line'
+  )
   .action(async (inputPaths, options) => {
     if (!inputPaths.length) {
       LOGGER.error(
@@ -33,7 +36,7 @@ program
     const iconSet = getIconConfigSet(inputPaths);
 
     // build all the icons
-    await build(iconSet, options.hashing);
+    await build(iconSet, options.hashing, options.debug);
 
     // exit without any errors
     process.exit(0);
@@ -48,6 +51,9 @@ program
     '-h, --hashing',
     'When true(default), builds only those icon variants that have changed since the previous execution. If false, builds all icons'
   )
+  .option(
+    '-d, --debug', 'Default is false.  When true, will log debugging info to the command-line'
+  )
   .action(async (inputPaths, options) => {
     if (!inputPaths.length) {
       LOGGER.error(
@@ -59,7 +65,7 @@ program
     const iconSet = getIconConfigSet(inputPaths);
 
     // generate all the icons
-    await iconGenerate.generateFromConfigHash(iconSet, options.hashing);
+    await iconGenerate.generateFromConfigHash(iconSet, options.hashing, options.debug);
 
     // exit without any errors
     process.exit(0);
@@ -85,6 +91,9 @@ program
   .option(
     '-h --outputAsTemplate',
     '[for web] whether to output the svg as handlebars template.'
+  )
+  .option(
+    '-d, --debug', 'Default is false.  When true, will log debugging info to the command-line'
   )
   .action(async (inputPaths, options) => {
     if (!inputPaths.length) {
@@ -126,7 +135,8 @@ program
       options.outputPath,
       options.type,
       options.groupBy === 'category',
-      options.outputAsTemplate
+      options.outputAsTemplate,
+      options.debug
     );
 
     // exit without any errors
@@ -141,15 +151,18 @@ program
     '-h, --hashing',
     'When true(default), builds only those icon variants that have changed since the previous execution. If false, builds all icons'
   )
+  .option(
+    '-d, --debug', 'Default is false.  When true, will log debugging info to the command-line'
+  )
   .action(async (inputPaths, options) => {
     // Get the iconSet from the inputPaths
     const iconSet = getIconConfigSet(inputPaths);
 
     // build all the icons
-    const outputIconSet = await build(iconSet, options.hashing);
+    const outputIconSet = await build(iconSet, options.hashing, options.debug);
 
     // generate all the icons
-    await iconGenerate.generate(outputIconSet, options.hashing);
+    await iconGenerate.generate(outputIconSet, options.hashing, options.debug);
 
     // exit without any errors
     process.exit(0);

--- a/packages/@icon-magic/cli/src/index.ts
+++ b/packages/@icon-magic/cli/src/index.ts
@@ -145,7 +145,7 @@ program
 
 // for all other commands or rather, no command and only arguments
 program
-  .command('* [inputPaths...]')
+  .command('* [inputPaths...]', { isDefault: true })
   .description('runs build and generate on all the inputPaths')
   .option(
     '-h, --hashing',

--- a/packages/@icon-magic/config-reader/src/config-loader.ts
+++ b/packages/@icon-magic/config-reader/src/config-loader.ts
@@ -1,9 +1,9 @@
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 const importFresh = require('import-fresh');
 
-const LOGGER: Logger = logger('icon-magic:config-reader:config-loader');
+const LOGGER = new Logger('icon-magic:config-reader:config-loader');
 
 /**
  * Loads a JavaScript configuration from a file.

--- a/packages/@icon-magic/config-reader/src/config.ts
+++ b/packages/@icon-magic/config-reader/src/config.ts
@@ -1,5 +1,5 @@
 import { IconConfig, IconConfigHash } from '@icon-magic/icon-models';
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import * as glob from 'glob';
 import * as path from 'path';
 
@@ -33,7 +33,7 @@ export class Config {
    * @param configFiles Takes in a set of config files
    */
   constructor(configFiles: string[]) {
-    this.LOGGER = logger('icon-magic/config-reader/config');
+    this.LOGGER = new Logger('icon-magic/config-reader/config');
 
     this.iconConfigHash = new Map();
     // For each config file, find the icons and it stands for and add them to the map

--- a/packages/@icon-magic/config-reader/src/index.ts
+++ b/packages/@icon-magic/config-reader/src/index.ts
@@ -1,5 +1,5 @@
 import { IconConfigHash } from '@icon-magic/icon-models';
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import * as glob from 'glob';
 import * as path from 'path';
 
@@ -7,7 +7,7 @@ import { Config } from './config';
 import { exists, isDirectory } from './helpers/files';
 
 const CONFIG_FILES = ['iconrc.json', 'iconrc.js'];
-const LOGGER: Logger = logger('icon-magic:config-reader/index');
+const LOGGER = new Logger('icon-magic:config-reader/index');
 
 export * from './config-loader';
 /**

--- a/packages/@icon-magic/distribute/src/create-image-set.ts
+++ b/packages/@icon-magic/distribute/src/create-image-set.ts
@@ -1,11 +1,11 @@
 import { Asset, IconSet } from '@icon-magic/icon-models';
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
 import { getAssetResolutionFromName, getIconFlavorsByType } from './utils';
 
-const LOGGER: Logger = logger('icon-magic:distribute:create-image-set');
+const LOGGER = new Logger('icon-magic:distribute:create-image-set');
 const IOS_SUPPORTED_RESOLUTIONS = [1, 2, 3];
 
 interface ContentImage {

--- a/packages/@icon-magic/distribute/src/create-sprite.ts
+++ b/packages/@icon-magic/distribute/src/create-sprite.ts
@@ -3,12 +3,12 @@ import {
   SpriteConfig,
   saveContentToFile
 } from '@icon-magic/icon-models';
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import { DOMImplementation, DOMParser, XMLSerializer } from 'xmldom';
 
 import { compareStrings, removeResolutionFromName } from './utils';
 
-const LOGGER: Logger = logger('icon-magic:distribute:create-sprite');
+const LOGGER = new Logger('icon-magic:distribute:create-sprite');
 const serializeToString = new XMLSerializer().serializeToString;
 
 /**
@@ -86,7 +86,7 @@ export function createSVGDoc(spriteName: string): { DOCUMENT: Document; svgEl: S
   svgEl.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
   svgEl.setAttribute('version', '1.1');
   svgEl.setAttribute('id', spriteName);
-  
+
   // Add <svg> element to SVG Document
   DOCUMENT.appendChild(svgEl);
   LOGGER.debug(`creating svg document ${DOCUMENT}`);

--- a/packages/@icon-magic/distribute/src/distribute-by-resolution.ts
+++ b/packages/@icon-magic/distribute/src/distribute-by-resolution.ts
@@ -1,10 +1,10 @@
 import { IconSet } from '@icon-magic/icon-models';
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
 import { getAssetResolutionFromName, getIconFlavorsByType } from './utils';
-const LOGGER: Logger = logger('icon-magic:distribute:distribute-by-resolution');
+const LOGGER = new Logger('icon-magic:distribute:distribute-by-resolution');
 
 const ICON_NAME_PREFIX = 'ic';
 

--- a/packages/@icon-magic/distribute/src/distribute-svg.ts
+++ b/packages/@icon-magic/distribute/src/distribute-svg.ts
@@ -1,5 +1,5 @@
 import { Asset, Icon, IconSet, SpriteConfig } from '@icon-magic/icon-models';
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
@@ -11,7 +11,7 @@ import {
 } from './create-sprite';
 import { compareStrings, getIconFlavorsByType } from './utils';
 
-const LOGGER: Logger = logger('icon-magic:distribute:distribute-svg');
+const LOGGER = new Logger('icon-magic:distribute:distribute-svg');
 
 /**
  *

--- a/packages/@icon-magic/distribute/src/index.ts
+++ b/packages/@icon-magic/distribute/src/index.ts
@@ -21,10 +21,8 @@ export async function distributeByType(
   outputPath: string,
   type: ICON_TYPES = 'all',
   groupByCategory = true,
-  outputAsHbs = false,
-  debug = false
+  outputAsHbs = false
 ): Promise<void> {
-  LOGGER.setDebug(debug);
   LOGGER.debug(`entering distribute with ${type}`);
   const iconSet = new IconSet(iconConfig, true);
   switch (type) {

--- a/packages/@icon-magic/distribute/src/index.ts
+++ b/packages/@icon-magic/distribute/src/index.ts
@@ -1,11 +1,11 @@
 import { IconConfigHash, IconSet } from '@icon-magic/icon-models';
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 
 import { createImageSet } from './create-image-set';
 import { distributeByResolution } from './distribute-by-resolution';
 import { distributeSvg } from './distribute-svg';
 
-const LOGGER: Logger = logger('icon-magic:distribute:index');
+const LOGGER = new Logger('icon-magic:distribute:index');
 type ICON_TYPES = 'svg' | 'png' | 'webp' | 'all';
 
 /**
@@ -22,7 +22,9 @@ export async function distributeByType(
   type: ICON_TYPES = 'all',
   groupByCategory = true,
   outputAsHbs = false,
+  debug = false
 ): Promise<void> {
+  LOGGER.setDebug(debug);
   LOGGER.debug(`entering distribute with ${type}`);
   const iconSet = new IconSet(iconConfig, true);
   switch (type) {

--- a/packages/@icon-magic/generate/src/generate-worker.ts
+++ b/packages/@icon-magic/generate/src/generate-worker.ts
@@ -8,7 +8,7 @@ import {
   applyPluginsOnAsset,
   saveContentToFile
 } from '@icon-magic/icon-models';
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import { existsSync } from 'fs-extra';
 import * as path from 'path';
 import * as workerpool from 'workerpool';
@@ -17,7 +17,7 @@ import { svgGenerate } from './plugins/svg-generate';
 import { svgToRaster } from './plugins/svg-to-raster';
 import { hasAssetBeenProcessed } from './utils';
 
-const LOGGER: Logger = logger('icon-magic:generate:index');
+const LOGGER = new Logger('icon-magic:generate:index');
 
 /**
  * generateSingleIcon transorms the set of .svg flavors of an icon to their

--- a/packages/@icon-magic/generate/src/index.ts
+++ b/packages/@icon-magic/generate/src/index.ts
@@ -1,10 +1,10 @@
 import { IconConfigHash, IconSet } from '@icon-magic/icon-models';
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import { timer } from '@icon-magic/timing';
 import * as path from 'path';
 import * as workerpool from 'workerpool';
 
-const LOGGER: Logger = logger('icon-magic:generate:index');
+const LOGGER = new Logger('icon-magic:generate:index');
 const TIMER = timer();
 const pool = workerpool.pool(path.resolve(__dirname, './generate-worker.js'));
 
@@ -21,9 +21,11 @@ const pool = workerpool.pool(path.resolve(__dirname, './generate-worker.js'));
  */
 export async function generate(
   iconSet: IconSet,
-  hashing = true
+  hashing = true,
+  debug = false
 ): Promise<void> {
   TIMER.start();
+  LOGGER.setDebug(debug);
   LOGGER.debug('Icon generation has begun');
 
   LOGGER.debug('Creating the worker pool');
@@ -59,8 +61,9 @@ export async function generate(
  */
 export async function generateFromConfigHash(
   iconConfig: IconConfigHash,
-  hashing = true
+  hashing = true,
+  debug = false
 ): Promise<void> {
   const iconSet = new IconSet(iconConfig, true);
-  return generate(iconSet, hashing);
+  return generate(iconSet, hashing, debug);
 }

--- a/packages/@icon-magic/generate/src/index.ts
+++ b/packages/@icon-magic/generate/src/index.ts
@@ -21,11 +21,9 @@ const pool = workerpool.pool(path.resolve(__dirname, './generate-worker.js'));
  */
 export async function generate(
   iconSet: IconSet,
-  hashing = true,
-  debug = false
+  hashing = true
 ): Promise<void> {
   TIMER.start();
-  LOGGER.setDebug(debug);
   LOGGER.debug('Icon generation has begun');
 
   LOGGER.debug('Creating the worker pool');
@@ -61,9 +59,8 @@ export async function generate(
  */
 export async function generateFromConfigHash(
   iconConfig: IconConfigHash,
-  hashing = true,
-  debug = false
+  hashing = true
 ): Promise<void> {
   const iconSet = new IconSet(iconConfig, true);
-  return generate(iconSet, hashing, debug);
+  return generate(iconSet, hashing);
 }

--- a/packages/@icon-magic/generate/src/plugins/svg-to-raster.ts
+++ b/packages/@icon-magic/generate/src/plugins/svg-to-raster.ts
@@ -7,13 +7,13 @@ import {
   createHash
 } from '@icon-magic/icon-models';
 import { minify } from '@icon-magic/imagemin-farm';
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import { convert } from '@icon-magic/svg-to-png';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
 const webp = require('webp-converter');
-const LOGGER: Logger = logger('icon-magic:generate:svg-to-raster');
+const LOGGER = new Logger('icon-magic:generate:svg-to-raster');
 
 /**
  * Optional values passed into the svg-to-raster plugin

--- a/packages/@icon-magic/icon-models/src/asset.ts
+++ b/packages/@icon-magic/icon-models/src/asset.ts
@@ -1,4 +1,4 @@
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import * as path from 'path';
 
 import { AssetConfig, Content } from './interface';
@@ -24,7 +24,7 @@ export class Asset {
    * @param config a config object to set the initial properties of the asset
    */
   constructor(iconPath: string, config: AssetConfig) {
-    this.LOGGER = logger('icon-magic:icon-models:asset');
+    this.LOGGER = new Logger('icon-magic:icon-models:asset');
 
     // if iconPath is not absolute, throw an error
     if (!path.isAbsolute(iconPath)) {

--- a/packages/@icon-magic/icon-models/src/icon-set.ts
+++ b/packages/@icon-magic/icon-models/src/icon-set.ts
@@ -1,4 +1,4 @@
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 
 import { Icon } from './icon';
 import { IconConfigHash, IconSetHash } from './interface';
@@ -22,7 +22,7 @@ export class IconSet {
    */
   constructor(iconConfigHash?: IconConfigHash, skipVariantCheck?: boolean) {
     this.hash = new Map();
-    this.LOGGER = logger('icon-magic:icon-models:icon-set');
+    this.LOGGER = new Logger('icon-magic:icon-models:icon-set');
 
     if (iconConfigHash) {
       // iterate through all the entires and add it to the map

--- a/packages/@icon-magic/icon-models/src/icon.ts
+++ b/packages/@icon-magic/icon-models/src/icon.ts
@@ -1,4 +1,4 @@
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import * as path from 'path';
 
 import { Asset } from './asset';
@@ -50,7 +50,7 @@ export class Icon {
    * have variants anymore
    */
   constructor(config: IconConfig, skipVariantCheck?: boolean) {
-    this.LOGGER = logger('icon-magic:icon-models:icon');
+    this.LOGGER = new Logger('icon-magic:icon-models:icon');
 
     // copy over all the properties in the config
     for (const key of Object.keys(config)) {

--- a/packages/@icon-magic/icon-models/src/plugin-manager.ts
+++ b/packages/@icon-magic/icon-models/src/plugin-manager.ts
@@ -1,4 +1,4 @@
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import * as path from 'path';
 
 import { Asset } from './asset';
@@ -7,7 +7,7 @@ import { Icon } from './icon';
 import { BuildPlugin, GeneratePlugin, Iterant } from './interface';
 import { saveContentToFile } from './utils/files';
 import { propCombinator } from './utils/prop-combinator';
-const LOGGER: Logger = logger('icon-magic:icon-models:plugin-manager');
+const LOGGER = new Logger('icon-magic:icon-models:plugin-manager');
 
 /**
  * Applies the set of plugins on the given asset and returns all the

--- a/packages/@icon-magic/imagemin-farm/src/index.ts
+++ b/packages/@icon-magic/imagemin-farm/src/index.ts
@@ -1,9 +1,9 @@
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from '@icon-magic/logger';
 import * as cluster from 'cluster';
 
 import { minifyFile } from './minify';
 
-const LOGGER: Logger = logger('icon-magic:png-minify');
+const LOGGER = new Logger('icon-magic:png-minify');
 const WORKERS: cluster.Worker[] = [];
 const STATUS: Map<number, WorkerState> = new Map();
 

--- a/packages/@icon-magic/logger/README.md
+++ b/packages/@icon-magic/logger/README.md
@@ -16,16 +16,16 @@ Logs are written to the following simulataneously:
 
 ```ts
 // Import the logger module and it's interface
-import { Logger, logger } from '@icon-magic/logger';
+import { Logger } from "@icon-magic/logger";
 
 // Instantiate by passing the name of the file. This will be a label in the log message
-const LOGGER: logger = logger('icon-magic:icon-models:asset');
+const LOGGER: logger = new Logger("icon-magic:icon-models:asset");
 
 // Log a debug message
-LOGGER.debug('Icon generation has begun');
+LOGGER.debug("Icon generation has begun");
 
 // Log an error message
-LOGGER.error('Oh no! An error has occurred!');
+LOGGER.error("Oh no! An error has occurred!");
 ```
 
 This will print logs of the following format:

--- a/packages/@icon-magic/logger/src/index.ts
+++ b/packages/@icon-magic/logger/src/index.ts
@@ -22,26 +22,37 @@ export const winstonLogger: winston.Logger = createLogger({
 /**
  * Wrapper around winston's logger
  */
-export interface Logger {
-  error: (msg: string) => void;
-  debug: (msg: string) => void;
-  info: (msg: string) => void;
+interface LoggerInterface {
+  error(msg: string): void;
+  debug(msg: string): void;
+  info(msg: string): void;
+  setDebug(debug: boolean): void;
 }
 
 /**
  * Wrapper around winston's logger that takes in a fileName
+ * @const debugState <boolean> defaults to false, passed in from cli flags.
+ * Using commander, -d or --debug flag will make this true.
  * @param fileName name of the file that's added as a label to the logging data
  */
-export function logger(fileName: string): Logger {
-  return {
-    error: function(msg: string): void {
-      winstonLogger.error({ message: msg, label: fileName });
-    },
-    debug: function(msg: string): void {
-      winstonLogger.debug({ message: msg, label: fileName });
-    },
-    info: function(msg: string): void {
-      winstonLogger.info({ message: msg, label: fileName });
+export class Logger implements LoggerInterface{
+  fileName: string;
+  static debugState: boolean = false;
+  constructor(fileName: string) {
+    this.fileName = fileName;
+  }
+  error(msg: string = ''): void {
+    winstonLogger.error({ message: msg, label: this.fileName });
+  }
+  debug(msg: string = ''): void {
+    if (Logger.debugState) {
+      winstonLogger.debug({ message: msg, label: this.fileName });
     }
-  };
+  }
+  info(msg: string): void {
+    winstonLogger.info({ message: msg, label: this.fileName });
+  }
+  setDebug(debug: boolean): void {
+    Logger.debugState = debug;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1992,7 +1992,7 @@ commander@^2.12.1, commander@~2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^5.0.0, commander@^5.1.0:
+commander@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1992,7 +1992,7 @@ commander@^2.12.1, commander@~2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^5.1.0:
+commander@^5.0.0, commander@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==


### PR DESCRIPTION
- users can use the -d, --debug flag with icon-magic/cli to see debug output
- changed the logger() wrapper function to the Logger class

Manual test running scripts works.

Addresses #14 