### PR TITLE
Distribute svg's by colorScheme

### DIFF
--- a/packages/@icon-magic/cli/package.json
+++ b/packages/@icon-magic/cli/package.json
@@ -24,7 +24,7 @@
     "@icon-magic/distribute": "^2.2.8-beta.0",
     "@icon-magic/generate": "^2.2.8-beta.0",
     "@icon-magic/logger": "^2.2.8-beta.0",
-    "commander": "^5.1.0",
+    "commander": "^7.2.0",
     "config-reader": "^0.1.1"
   }
 }

--- a/packages/@icon-magic/cli/src/index.ts
+++ b/packages/@icon-magic/cli/src/index.ts
@@ -101,6 +101,9 @@ program
   .option(
     '-d, --debug', 'Default is false.  When true, will log debugging info to the command-line'
   )
+  .option(
+    '-c, --colorScheme <colorScheme...>', 'With no flag, `light` and `dark` colorSchemes are distributed. Other colorSchemes can be specified with flag'
+  )
   .action(async (inputPaths, options) => {
     if (!inputPaths.length) {
       LOGGER.error('No Input Directories were specified.\n');
@@ -145,6 +148,7 @@ program
       options.type,
       options.groupBy === 'category',
       options.outputAsTemplate,
+      options.colorScheme
     );
 
     // exit without any errors

--- a/packages/@icon-magic/distribute/src/distribute-svg.ts
+++ b/packages/@icon-magic/distribute/src/distribute-svg.ts
@@ -18,6 +18,7 @@ const LOGGER = new Logger('icon-magic:distribute:distribute-svg');
  * @param iconSet set of icons to be moved to the output folder or added to sprite
  * @param outputPath path to move to
  * @param groupByCategory (for sprite creation) whether to group by the category attribute
+ * @param colorScheme array of strings matching the colorScheme attributes of the icon ie: `light`, `dark`, `mixed`.
  * @returns promise after completion
  */
 export async function distributeSvg(
@@ -25,6 +26,7 @@ export async function distributeSvg(
   outputPath: string,
   groupByCategory: boolean,
   outputAsHbs: boolean,
+  colorScheme: string[]
 ): Promise<void> {
   // Sort icons so it looks pretty in .diff
   const icons = sortIcons(iconSet.hash.values());
@@ -33,8 +35,21 @@ export async function distributeSvg(
   const spriteNames: SpriteConfig = {};
   const promises: void[] = [];
   for (const icon of icons) {
-    LOGGER.debug(`calling distributeSvg on ${icon.iconName}: ${icon.iconPath}`);
+    LOGGER.debug(`calling distributeSvg on ${icon.iconName}: ${icon.iconPath} with colorScheme: ${colorScheme}`);
     const assets = getIconFlavorsByType(icon, 'svg');
+
+    // Further filter the icons by matching the assets's colorScheme to the commander option --colorScheme
+    const assetsByColorScheme = assets.filter(asset => {
+      if(asset.colorScheme) {
+        return colorScheme.includes(asset.colorScheme);
+      } else if (asset.colorScheme === undefined){
+        // Light variants can either have colorScheme: `light` or undefined
+        return colorScheme.includes('light');
+      } else {
+        return false;
+      }
+    });
+
     const distributeConfig = icon.distribute;
     const svgConfig = distributeConfig && distributeConfig.svg;
     // variantsToFilter can be defined on distribute or on distribute.svg
@@ -46,8 +61,8 @@ export async function distributeSvg(
     // If icon has defined the assets to go to sprite
     const { assetsToAddToSprite, assetsNoSprite } =
       variantsToFilter && variantsToFilter.length
-        ? partitionAssetsForSprite(assets, variantsToFilter)
-        : { assetsToAddToSprite: assets, assetsNoSprite: assets };
+        ? partitionAssetsForSprite(assetsByColorScheme, variantsToFilter)
+        : { assetsToAddToSprite: assetsByColorScheme, assetsNoSprite: assetsByColorScheme };
 
     const iconHasSpriteConfig = !(
       distributeConfig &&
@@ -56,7 +71,7 @@ export async function distributeSvg(
     );
     if (outputAsHbs) {
       try {
-        await createHbs(assets, outputPath);
+        await createHbs(assetsByColorScheme, outputPath);
       }
       catch(e) {
         LOGGER.debug(`There was an issue creating the hbs file: ${e}`);

--- a/packages/@icon-magic/distribute/src/index.ts
+++ b/packages/@icon-magic/distribute/src/index.ts
@@ -14,6 +14,7 @@ type ICON_TYPES = 'svg' | 'png' | 'webp' | 'all';
  * @param outputPath output directory path to copy the assets to
  * @param type svg, png, webp, all
  * @param groupByCategory (for sprite creation) whether to group by the category attribute
+ * @param colorScheme array of strings matching the colorScheme attributes of the icon ie: `light`, `dark`, `mixed`.
  * @retuns promise after completion
  */
 export async function distributeByType(
@@ -21,9 +22,10 @@ export async function distributeByType(
   outputPath: string,
   type: ICON_TYPES = 'all',
   groupByCategory = true,
-  outputAsHbs = false
+  outputAsHbs = false,
+  colorScheme: string[] = ['light', 'dark']
 ): Promise<void> {
-  LOGGER.debug(`entering distribute with ${type}`);
+  LOGGER.debug(`entering distribute with ${type} and colorSchemes: ${colorScheme}`);
   const iconSet = new IconSet(iconConfig, true);
   switch (type) {
     case 'png': {
@@ -35,13 +37,13 @@ export async function distributeByType(
       break;
     }
     case 'svg': {
-      await distributeSvg(iconSet, outputPath, groupByCategory, outputAsHbs);
+      await distributeSvg(iconSet, outputPath, groupByCategory, outputAsHbs, colorScheme);
       break;
     }
     default: {
       await createImageSet(iconSet, outputPath);
       await distributeByResolution(iconSet, outputPath);
-      await distributeSvg(iconSet, outputPath, groupByCategory, outputAsHbs);
+      await distributeSvg(iconSet, outputPath, groupByCategory, outputAsHbs, colorScheme);
     }
   }
 }

--- a/packages/@icon-magic/generate/src/plugins/svg-generate.ts
+++ b/packages/@icon-magic/generate/src/plugins/svg-generate.ts
@@ -187,7 +187,9 @@ export const svgGenerate: GeneratePlugin = {
       'svg',
       new Asset(icon.iconPath, {
         name: flavor.name,
-        path: `./${flavor.name}.svg`
+        path: `./${flavor.name}.svg`,
+        imageset: flavor.imageset,
+        colorScheme: flavor.colorScheme
       })
     );
     return flavor;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1992,10 +1992,10 @@ commander@^2.12.1, commander@~2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
-  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 commander@~2.8.1:
   version "2.8.1"


### PR DESCRIPTION
- can now distribute svg's by colorScheme
- bumped commander to 7.2.0 to make variadic arguments work on options
- added colorScheme and imageset to svg-generate so that distribute can access colorScheme in Asset by svg type

Tested locally and works for all our use cases.  Default is `light` and `dark`.  Flag `-c mixed` or any combination works.

Still need tests and docs.