### PR TITLE
trim "-mixed" from end of hbs files when distributed

### DIFF
--- a/packages/@icon-magic/cli/src/index.ts
+++ b/packages/@icon-magic/cli/src/index.ts
@@ -103,6 +103,8 @@ program
   )
   .option(
     '-c, --colorScheme <colorScheme...>', 'With no flag, `light` and `dark` colorSchemes are distributed. Other colorSchemes can be specified with flag'
+  )  .option(
+    '-s, --doNotRemoveSuffix', 'When used with --outputAsTemplate, will NOT trim the "-mixed" suffix on the file name'
   )
   .action(async (inputPaths, options) => {
     if (!inputPaths.length) {
@@ -135,6 +137,12 @@ program
       process.exit(1);
     }
 
+    // --doNotRemoveSuffix is only for --outputAsTemplate flag
+    if (options.doNotRemoveSuffix && !options.outputAsTemplate) {
+      LOGGER.error('Option --doNotRemoveSuffix must be used with --outputAsTemplate flag');
+      process.exit(1);
+    }
+
     // Get the iconSet from the inputPaths
     const iconSet = getIconConfigSet(inputPaths);
 
@@ -148,7 +156,8 @@ program
       options.type,
       options.groupBy === 'category',
       options.outputAsTemplate,
-      options.colorScheme
+      options.colorScheme,
+      options.doNotRemoveSuffix
     );
 
     // exit without any errors

--- a/packages/@icon-magic/distribute/src/create-icon-template.ts
+++ b/packages/@icon-magic/distribute/src/create-icon-template.ts
@@ -31,7 +31,7 @@ export async function createHbs(
     // Strip id
     el.removeAttribute('id');
     // Remove the "-mixed" suffix from the name. File will have same name as light version.
-    if (!doNotRemoveSuffix) {
+    if (!doNotRemoveSuffix && asset.colorScheme === 'mixed') {
       iconName = iconName.replace(/-mixed$/, '');
     }
 

--- a/packages/@icon-magic/distribute/src/create-icon-template.ts
+++ b/packages/@icon-magic/distribute/src/create-icon-template.ts
@@ -11,10 +11,12 @@ const serializeToString = new XMLSerializer().serializeToString;
  * Saves svg assets as handlebars files
  * @param assets SVG assets to convert
  * @param outputPath path to write to
+ * @param doNotRemoveSuffix boolean, when true will keep the "-mixed" suffix in file name when distributing to hbs.
  */
 export async function createHbs(
   assets: Asset[],
   outputPath: string,
+  doNotRemoveSuffix: boolean
 ): Promise<void> {
   for (const asset of assets) {
     const doc = new DOMParser();
@@ -25,9 +27,13 @@ export async function createHbs(
     const xml = doc.parseFromString(contents as string, 'image/svg+xml');
     const el = xml.documentElement;
     const id = el.getAttributeNode('id');
-    const iconName = id ? id.value : '';
+    let iconName = id ? id.value : '';
     // Strip id
     el.removeAttribute('id');
+    // Remove the "-mixed" suffix from the name. File will have same name as light version.
+    if (!doNotRemoveSuffix) {
+      iconName = iconName.replace(/-mixed$/, '');
+    }
 
     // add splattributes to the hbs file
     xml.documentElement.setAttribute('...attributes', '');

--- a/packages/@icon-magic/distribute/src/distribute-svg.ts
+++ b/packages/@icon-magic/distribute/src/distribute-svg.ts
@@ -39,7 +39,7 @@ export async function distributeSvg(
   for (const icon of icons) {
     LOGGER.debug(`calling distributeSvg on ${icon.iconName}: ${icon.iconPath} with colorScheme: ${colorScheme}`);
     if (!doNotRemoveSuffix && colorScheme.includes('mixed')){
-      LOGGER.warn(`Warning: By default the "-mixed" suffix is trimed from the file name when distributed to hbs. The file name will be the SAME as the light variant. Use the --doNotRemoveSuffix flag to keep the "-mixed" in the file name.`);
+      LOGGER.warn(`Warning: By default the "-mixed" suffix is trimmed from the file name when distributed to hbs. The file name will be the SAME as the light variant. Use the --doNotRemoveSuffix flag to keep the "-mixed" in the file name.`);
     }
 
     const assets = getIconFlavorsByType(icon, 'svg');

--- a/packages/@icon-magic/distribute/src/index.ts
+++ b/packages/@icon-magic/distribute/src/index.ts
@@ -25,7 +25,7 @@ export async function distributeByType(
   groupByCategory = true,
   outputAsHbs = false,
   colorScheme: string[] = ['light', 'dark'],
-  doNotRemoveSuffix: boolean = false
+  doNotRemoveSuffix = false
 ): Promise<void> {
   LOGGER.debug(`entering distribute with ${type} and colorSchemes: ${colorScheme}`);
   const iconSet = new IconSet(iconConfig, true);

--- a/packages/@icon-magic/distribute/src/index.ts
+++ b/packages/@icon-magic/distribute/src/index.ts
@@ -15,6 +15,7 @@ type ICON_TYPES = 'svg' | 'png' | 'webp' | 'all';
  * @param type svg, png, webp, all
  * @param groupByCategory (for sprite creation) whether to group by the category attribute
  * @param colorScheme array of strings matching the colorScheme attributes of the icon ie: `light`, `dark`, `mixed`.
+ * @param doNotRemoveSuffix boolean, when true will keep the "-mixed" suffix in file name when distributing to hbs.
  * @retuns promise after completion
  */
 export async function distributeByType(
@@ -23,7 +24,8 @@ export async function distributeByType(
   type: ICON_TYPES = 'all',
   groupByCategory = true,
   outputAsHbs = false,
-  colorScheme: string[] = ['light', 'dark']
+  colorScheme: string[] = ['light', 'dark'],
+  doNotRemoveSuffix: boolean = false
 ): Promise<void> {
   LOGGER.debug(`entering distribute with ${type} and colorSchemes: ${colorScheme}`);
   const iconSet = new IconSet(iconConfig, true);
@@ -37,13 +39,13 @@ export async function distributeByType(
       break;
     }
     case 'svg': {
-      await distributeSvg(iconSet, outputPath, groupByCategory, outputAsHbs, colorScheme);
+      await distributeSvg(iconSet, outputPath, groupByCategory, outputAsHbs, colorScheme, doNotRemoveSuffix);
       break;
     }
     default: {
       await createImageSet(iconSet, outputPath);
       await distributeByResolution(iconSet, outputPath);
-      await distributeSvg(iconSet, outputPath, groupByCategory, outputAsHbs, colorScheme);
+      await distributeSvg(iconSet, outputPath, groupByCategory, outputAsHbs, colorScheme, doNotRemoveSuffix);
     }
   }
 }

--- a/packages/@icon-magic/logger/src/index.ts
+++ b/packages/@icon-magic/logger/src/index.ts
@@ -26,6 +26,7 @@ interface LoggerInterface {
   error(msg: string): void;
   debug(msg: string): void;
   info(msg: string): void;
+  warn(msg: string): void;
   setDebug(debug: boolean): void;
 }
 
@@ -51,6 +52,9 @@ export class Logger implements LoggerInterface{
   }
   info(msg: string): void {
     winstonLogger.info({ message: msg, label: this.fileName });
+  }
+  warn(msg: string): void {
+    winstonLogger.warn({ message: msg, label: this.fileName });
   }
   setDebug(debug: boolean): void {
     Logger.debugState = debug;


### PR DESCRIPTION
- Now by default, "-mixed" is trimmed from end of file names when distributed as hbs.
- add --doNotRemoveSuffix flag to prevent default behavior
- add warn function to LOGGER
- warn users of default trimming behavior

Tested locally